### PR TITLE
fix: fix decrease key methods in Fibonacci heap

### DIFF
--- a/src/main/java/org/jheaps/tree/FibonacciHeap.java
+++ b/src/main/java/org/jheaps/tree/FibonacciHeap.java
@@ -492,7 +492,7 @@ public class FibonacciHeap<K, V> implements MergeableAddressableHeap<K, V>, Seri
         if (c > 0) {
             throw new IllegalArgumentException("Keys can only be decreased!");
         }
-        n.key = newKey;
+        
         if (c == 0) {
             return;
         }
@@ -500,6 +500,8 @@ public class FibonacciHeap<K, V> implements MergeableAddressableHeap<K, V>, Seri
         if (n.next == null) {
             throw new IllegalArgumentException("Invalid handle!");
         }
+
+        n.key = newKey;
 
         // if not root and heap order violation
         Node<K, V> y = n.parent;
@@ -522,7 +524,7 @@ public class FibonacciHeap<K, V> implements MergeableAddressableHeap<K, V>, Seri
         if (c > 0) {
             throw new IllegalArgumentException("Keys can only be decreased!");
         }
-        n.key = newKey;
+        
         if (c == 0) {
             return;
         }
@@ -530,6 +532,8 @@ public class FibonacciHeap<K, V> implements MergeableAddressableHeap<K, V>, Seri
         if (n.next == null) {
             throw new IllegalArgumentException("Invalid handle!");
         }
+
+        n.key = newKey;
 
         // if not root and heap order violation
         Node<K, V> y = n.parent;


### PR DESCRIPTION
The above pull request fixes possible issue in two descrease methods in Fibonacci heap. The idea is that there is no sense in changing node's key to a new one, if the keys are equal or if the node is invalid.